### PR TITLE
no outdated shaming

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 3,
   "description": "Provide some features helpful for WebGPU Development",
   "default_locale": "en",
-  "minimum_chrome_version": "113",
+  "minimum_chrome_version": "1",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAg/wAu86aayfkDEvVAGgdtl8FS2/axn1JqdDl9awFDUdSLZrCNJ/7vMJBEUp3IpgzBMF+qFH9UZFQJIuyo2vRHnmIXDMVXEfYLmIJ9WfMYQnu8sUvcTilj7zCzaWSyo1/VqGeahsRX18VZBaMyOc4vauSojZFi66ZkR+dd9JoPhbxFFAMrcZkYeoIL27+ofKRy01gCBN/p3kQtowfvQtxGA+5irSqspXPtFIeTY20ZBhGaYR1KXu9wwa9ghtuQPf00Gy8+FyDzFwemawJ3KjlATokTjqEw9Z8ZM1kB6sS0q50xSJUhlbQ+/FMFN0owm7K5UHTSXGOALS8YPnHASeP3wIDAQAB",
   "permissions": [
     "debugger"


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)